### PR TITLE
Notifications on Linux and option to disable notifications altogether.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ templates, you will want to bootstrap the files.  To save time you can run
 the following to automatically build everything in the source folder.
 
     $ ./dust-compiler --bootstrap
+
+
+## Disabling notifications
+Don't like the notifications?  Prefer to watch the terminal window instead?
+
+    $ ./dust-compiler --no-notify

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Dust Compiler
 This is a basic dust compiler, there are many out there. This one adds support
-for OS X 10.8.x Notification Center to bring more visiblity to compile errors
-when developing while the terminal window that it is running in is not visible.
+for the OS X 10.8.x Notification Center and notifications on modern Linux
+desktops to bring more visiblity to compile errors when developing while the
+terminal window that it is running in is not visible.
 
 
 ## Install
@@ -15,6 +16,11 @@ your project folder.  Edit the file and set the `source` and `destination`
 paths on where it should watch for dust files (source), and where it should
 write compiled js files (destination).
 
+
+### Enabling notifications in Linux
+Many Linux distributions ship with the `notify-send` tool already installed.
+If not, you will need to install the "libnotify-bin" (Ubuntu) or "libnotify"
+(RedHat / Fedora) packages.
 
 
 ## Turning it on

--- a/dust-compiler.js
+++ b/dust-compiler.js
@@ -48,7 +48,8 @@ var source = "src/main/dust-templates/",             // must end in slash
         default:
             return console.log;
         }
-    }());
+    }()),
+    bootstrap = false;
 
 function compile(path, curr, prev) {
     'use strict';
@@ -84,7 +85,23 @@ function compile(path, curr, prev) {
 }
 
 
-if (process.argv[2] === '--bootstrap') {
+process.argv.forEach(function (arg, idx) {
+    "use strict";
+    if (idx < 2) { return; }
+
+    switch (arg) {
+    case "--bootstrap":
+        bootstrap = true;
+        break;
+    case "--no-notify":
+        log = console.log;
+        break;
+    default:
+        log("Ignoring unrecognized option: " + arg);
+    }
+});
+
+if (bootstrap) {
     wrench.readdirRecursive(source, function (error, fileList) {
         'use strict';
 

--- a/dust-compiler.js
+++ b/dust-compiler.js
@@ -23,23 +23,32 @@ var source = "src/main/dust-templates/",             // must end in slash
     fs = require('fs'),
     dust = require('dustjs-linkedin'),
     watch = require('watch'),
-    notifier = require('terminal-notifier'),
-    wrench = require('wrench');
+    wrench = require('wrench'),
+    log = (function () {
+        "use strict";
+        var notifier;
 
-
-function log(message) {
-    'use strict';
-
-    if (process.platform === 'darwin') {
-        notifier(message, {
-            title: 'Dust Compiler',
-            activate: 'com.apple.Terminal'
-        });
-    }
-
-    console.log(message);
-}
-
+        // Determine the most-appropriate notifier for the platform.
+        switch (process.platform) {
+        case "darwin":
+            notifier = require("terminal-notifier");
+            return function (message) {
+                notifier(message, {
+                    title: 'Dust Compiler',
+                    activate: 'com.apple.Terminal'
+                });
+                console.log(message);
+            };
+        case "linux":
+            notifier = require("notify-send");
+            return function (message) {
+                notifier.notify("Dust Compiler", message);
+                console.log(message);
+            };
+        default:
+            return console.log;
+        }
+    }());
 
 function compile(path, curr, prev) {
     'use strict';

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     },
     "dependencies": {
         "dustjs-linkedin": "1.2.1",
+        "notify-send": "0.1.2",
         "watch": "0.5.1",
         "terminal-notifier": "0.1.0",
         "wrench": "1.4.4"


### PR DESCRIPTION
This adds support for notifications on modern Linux systems via notify-send.

It also adds a new `--no-notify` command-line option to disable the notifications on both OS X and Linux.
