### PR TITLE
Change compile path to ouput source

### DIFF
--- a/dust-compiler.js
+++ b/dust-compiler.js
@@ -77,9 +77,9 @@ function compile(src, curr, prev) {
             if (!stat.isDirectory()) {
 
                 filename = src.substring(source.length);
+                filepath = destination + filename;
                 basename = filename.substring(0, filename.length - 5);
-                compileFilename = argv.includepath ? destination + basename : basename;
-                filepath = destination + basename + '.js';
+                compileFilename = argv.includepath ? source + basename : basename;
 
                 fs.readFile(src, function (err, data) {
                     if (err) {
@@ -106,7 +106,7 @@ function compile(src, curr, prev) {
                                     log('[ERROR]'.red + ' fs.writeFile: ' + err);
                                     throw err;
                                 }
-                                log('Compiled '.green + filepath + ' as '.green + compileFilename);
+                                log('Compiled '.green + source + filename + ' as '.green + compileFilename);
                             });
                         });
                     }


### PR DESCRIPTION
Since the goal is to use the same module for both server-side and
client-side includes, both must register the path name to the source
dust template. Only client-side templates care about the .js version.
- Change compile path to source basename
- Rearrange variables for cleanliness
- Change log message to read [source filepath] as [source basename]
