### PR TITLE
Use node-growl instead of notify-send directly.

### DIFF
--- a/dust-compiler.js
+++ b/dust-compiler.js
@@ -44,9 +44,10 @@ if (argv.nonotify) {
             };
 
         case 'linux':
-            notifier = require('notify-send');
+        case 'win32':
+            notifier = require('growl');
             return function (message) {
-                notifier.notify('Dust Compiler', message.stripColors);
+                notifier(message.stripColors, { title: 'Dust Compiler' });
                 console.log(message);
             };
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "colors": "0.6.0-1",
         "dustjs-linkedin": "1.2.3",
         "mkdirp": "0.3.5",
-        "notify-send": "0.1.2",
+        "growl": "1.x",
         "optimist": "0.4.0",
         "terminal-notifier": "0.1.0",
         "watch": "0.7.0",


### PR DESCRIPTION
This allows us to support both Linux and Windows (via Growl for
Windows).  On Linux, we still use notify-send, albeit via node-growl.

See: https://github.com/visionmedia/node-growl
