### PR TITLE
fix doubled-pathname problem

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -16,7 +16,7 @@ module.exports = function compile(sourceFilename, sourcePath, destinationPath, o
         compileFilename;
 
     sourcePath = sourcePath || './';
-    sourceFilename = sourceFilename || '';
+    sourceFilename = path.basename(sourceFilename) || '';
     destinationPath = destinationPath || './';
     options = options || {};
     options.includepath = options.includepath || false;
@@ -75,7 +75,7 @@ module.exports = function compile(sourceFilename, sourcePath, destinationPath, o
                                     log('ERROR: '.red + 'fs.writeFile: ' + error.message);
                                     throw error;
                                 }
-                                log('Compiled '.green + sourcePath + sourceFilename + ' as '.green + compileFilename);
+                                log('Compiled '.green + sourcePath + sourceFilename + ' as '.green + destinationPath + compileFilename);
                             });
                         });
                     }


### PR DESCRIPTION
sourceFilename as passed into compile() sometimes already includes a path. Fix is to strip the path using path.basename(). (Also added destinationPath to the log output.)
